### PR TITLE
Add install instruction to uniquify Bundle Identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,18 @@ How do I get this on my phone?
 
 1.  Download (click releases above for file), then open with Xcode
 
-2.  Plug in your phone
+2.  In the Project Editor, go to General > Identity > Bundle Identifier and
+    append some characters to the identifier string to make it unique
+    (anything but `com.justgetflux.iflux`) or you may get an error saying "An
+    App ID with Identifier 'com.justgetflux.iflux' is not available. Please
+    enter a different string."
 
-3.  Select your phone from the device menu (next to the "Play" and "Stop"
+3.  Plug in your phone
+
+4.  Select your phone from the device menu (next to the "Play" and "Stop"
     buttons)
 
-4.  Click "Play"
+5.  Click "Play"
 
 How does it work?
 -----------------


### PR DESCRIPTION
If your bundle identifier is the default one, i.e. `com.justgetflux.iflux`, Xcode will throw an error saying

<img width="445" alt="screen shot 2016-03-12 at 5 40 58 pm" src="https://cloud.githubusercontent.com/assets/962615/13722872/9f1658c6-e879-11e5-9f43-c7902d6f8ea1.png">

I've added a step in the install instructions requesting people to change (uniquify) their Bundle Identifier before trying to build/install.
